### PR TITLE
fix: re-add qiskit-aer package

### DIFF
--- a/qiskit/requirements.txt
+++ b/qiskit/requirements.txt
@@ -4,5 +4,6 @@
 # required for Qiskit MaxCut solver
 numpy
 pygmlparser
-qiskit
+qiskit == 0.44.*
 qiskit_optimization
+qiskit-aer


### PR DESCRIPTION
The 0.44.0 release of the qiskit metapackage removed qiskit-aer which we now have to require explicitly.