### PR TITLE
refactor: use ids for ProblemType serialization instead of enum names

### DIFF
--- a/src/main/java/edu/kit/provideq/toolbox/meta/ProblemType.java
+++ b/src/main/java/edu/kit/provideq/toolbox/meta/ProblemType.java
@@ -1,5 +1,6 @@
 package edu.kit.provideq.toolbox.meta;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import edu.kit.provideq.toolbox.SolveRequest;
 import edu.kit.provideq.toolbox.featuremodel.SolveFeatureModelRequest;
 import edu.kit.provideq.toolbox.maxcut.SolveMaxCutRequest;
@@ -50,6 +51,7 @@ public enum ProblemType {
   /**
    * Returns a unique identifier for this problem type.
    */
+  @JsonValue
   public String getId() {
     return id;
   }

--- a/src/main/java/edu/kit/provideq/toolbox/meta/SubRoutineDefinition.java
+++ b/src/main/java/edu/kit/provideq/toolbox/meta/SubRoutineDefinition.java
@@ -4,21 +4,10 @@ package edu.kit.provideq.toolbox.meta;
  * A sub-routine definition describes which problem type needs to be solved by a sub-routine and why
  * it needs to be solved.
  *
- * @param problemTypeId {@link ProblemType#getId() id} of the problem type that needs to be solved
+ * @param type {@link ProblemType} that needs to be solved
  *     by this sub-routine.
  * @param description description of the sub-routine call to provide information where and why it is
  *     needed.
- * @see #SubRoutineDefinition(ProblemType, String)
  */
-public record SubRoutineDefinition(String problemTypeId, String description) {
-  /**
-   * Creates a sub-routine definition for a given problem type with a given description.
-   *
-   * @param type problem type that needs to be solved by this sub-routine.
-   * @param description description of the sub-routine call to provide information where and why it
-   *     is needed.
-   */
-  public SubRoutineDefinition(ProblemType type, String description) {
-    this(type.getId(), description);
-  }
+public record SubRoutineDefinition(ProblemType type, String description) {
 }


### PR DESCRIPTION
This PR makes sure that `ProblemType`s are identified through their `id` attribute instead of their enum name. This decouples the names of our Java constants from the actual problem type identifiers.