### PR TITLE
Update Docker Image for Qrisp SAT Solver

### DIFF
--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -7,7 +7,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     container:
-      image: debian:bullseye-slim # use the same image as our docker runner
+      image: debian:bookworm-slim # use the same image as our docker runner
     steps:
       - name: Clone repo (shallow)
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN jlink \
     --compress=2
 
 # Step 2: Install the toolbox + external dependencies to a runner container
-FROM debian:bullseye-slim AS runner
+FROM debian:bookworm-slim AS runner
 WORKDIR /app
 
 COPY scripts scripts


### PR DESCRIPTION
- Works on #110 
- This Branch is required as a dependency for feat/sharp-sat and feat/exact-qrisp-sat-solver