### PR TITLE
updated actions to v4

### DIFF
--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -10,11 +10,11 @@ jobs:
       image: debian:bookworm-slim # use the same image as our docker runner
     steps:
       - name: Clone repo (shallow)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -36,13 +36,13 @@ jobs:
           ./gradlew check --info
       - name: Archive test reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-report
           path: build/reports/tests/test/
       - name: Archive style reports
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: style-report
           path: build/reports/checkstyle/
@@ -53,7 +53,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/develop' }}
     steps:
       - name: Clone repo (shallow)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Push to dokku

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Actions V3 are depricated, which caused the pipeline to fail.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/