### PR TITLE
Update Install Solvers Script

### DIFF
--- a/scripts/ci-setup-solvers.sh
+++ b/scripts/ci-setup-solvers.sh
@@ -7,6 +7,13 @@ set -e
 # get base directory of the repository
 REPO_DIR=$(dirname "$(dirname "$(readlink -f "$0")")")
 
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc \
+    g++ \
+    python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 # make sure to install to the gams conda env
 source /opt/conda/bin/activate gams
 

--- a/scripts/setup-gams.sh
+++ b/scripts/setup-gams.sh
@@ -19,7 +19,7 @@ apt-get install curl --yes
 # iisaa/gams-docker (https://github.com/iiasa/gams-docker/blob/master/Dockerfile, GPL-3.0 licensed)
 
 # Configure the GAMS version here
-GAMS_VERSION_RELEASE_MAJOR=49.7
+GAMS_VERSION_RELEASE_MAJOR=52.5
 GAMS_VERSION_HOTFIX=0
 
 # download the self-extracting archive to /opt/gams/gams.exe and run/extract it

--- a/src/test/java/edu/kit/provideq/toolbox/api/ApiTestHelper.java
+++ b/src/test/java/edu/kit/provideq/toolbox/api/ApiTestHelper.java
@@ -153,11 +153,17 @@ public class ApiTestHelper {
           })
           .returnResult()
           .getResponseBody();
-      builder.append("Fetched problem: " + problemDto + "\n");
 
+      if (problemDto == null) {
+        System.out.println("Testcase with id " + problemId + " will terminate because problemDto is null");
+        System.out.println("problemType: " + problemType);
+      }
       assertNotNull(problemDto);
 
+      builder.append("Fetched problem: " + problemDto + "\n");
+
       if (problemDto.getState() == ProblemState.SOLVED) {
+        System.out.println(problemId + " solved successful.");
         break;
       }
 
@@ -174,6 +180,11 @@ public class ApiTestHelper {
               .getResponseBody();
           builder.append("Fetched sub problem: " + subProblemDto + "\n");
 
+          if (subProblemDto == null) {
+            System.out.println("Subproblem with id " + subProblemId + " will terminate because subProblemDto is null");
+            System.out.println("subProblem: " + subProblem);
+            System.out.println("Log: " + builder);
+          }
           assertNotNull(subProblemDto);
         }
       }
@@ -187,6 +198,8 @@ public class ApiTestHelper {
       }
 
       if (hasTimeout.get()) {
+        System.out.print("Stopping testcase due to timeout.");
+        System.out.println("log: " + builder);
         throw new IllegalStateException("Problem did not solve in time: " + problemDto);
       }
     }

--- a/src/test/java/edu/kit/provideq/toolbox/api/ApiTestHelper.java
+++ b/src/test/java/edu/kit/provideq/toolbox/api/ApiTestHelper.java
@@ -200,7 +200,7 @@ public class ApiTestHelper {
       }
 
       if (hasTimeout.get()) {
-        System.out.print("Stopping testcase due to timeout.");
+        System.out.println("Stopping testcase due to timeout.");
         System.out.println("log: " + builder);
         throw new IllegalStateException("Problem did not solve in time: " + problemDto);
       }

--- a/src/test/java/edu/kit/provideq/toolbox/api/ApiTestHelper.java
+++ b/src/test/java/edu/kit/provideq/toolbox/api/ApiTestHelper.java
@@ -155,7 +155,8 @@ public class ApiTestHelper {
           .getResponseBody();
 
       if (problemDto == null) {
-        System.out.println("Testcase with id " + problemId + " will terminate because problemDto is null");
+        System.out.println("Testcase with id " + problemId
+            + " will terminate because problemDto is null");
         System.out.println("problemType: " + problemType);
       }
       assertNotNull(problemDto);
@@ -181,7 +182,8 @@ public class ApiTestHelper {
           builder.append("Fetched sub problem: " + subProblemDto + "\n");
 
           if (subProblemDto == null) {
-            System.out.println("Subproblem with id " + subProblemId + " will terminate because subProblemDto is null");
+            System.out.println("Subproblem with id " + subProblemId
+                + " will terminate because subProblemDto is null");
             System.out.println("subProblem: " + subProblem);
             System.out.println("Log: " + builder);
           }


### PR DESCRIPTION
new commands to install compilers that might be needed for solver installment.

This PR is necessary because the building of new docker images is currently only working in the CI, but not on our ProvideQ server. The building there failed because the following package could not be build:
```
390.9 Building wheels for collected packages: rectangle-packer
390.9   Building wheel for rectangle-packer (pyproject.toml): started
390.9   Building wheel for rectangle-packer (pyproject.toml): finished with status 'error'
390.9 Failed to build rectangle-packer
```