### PR TITLE
Fixed install Script Instruction

### DIFF
--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash # required for the source command
         run: | # change to "./gradlew check --info" for more debugging output.
           source /opt/conda/bin/activate gams
-          ./gradlew check
+          ./gradlew check --info
 
       - name: Archive test reports
         if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,14 @@ RUN jlink \
 FROM debian:bookworm-slim AS runner
 WORKDIR /app
 
+# Install system build tools, needed to build solver dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gcc \
+    g++ \
+    python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY scripts scripts
 
 # Install GAMS with conda python environment

--- a/scripts/ci-setup-solvers.sh
+++ b/scripts/ci-setup-solvers.sh
@@ -7,13 +7,6 @@ set -e
 # get base directory of the repository
 REPO_DIR=$(dirname "$(dirname "$(readlink -f "$0")")")
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    gcc \
-    g++ \
-    python3-dev \
-    && rm -rf /var/lib/apt/lists/*
-
 # make sure to install to the gams conda env
 source /opt/conda/bin/activate gams
 


### PR DESCRIPTION
Accidentally added the GCC builder installation to the wrong location...
Ci pipeline did not care about this, but it caused the server to still have error.

Solution: Moved install command to the correct location (in Dockerfile not in script)